### PR TITLE
Kokkos Versions: fix illegal initialization of Kokkos Views

### DIFF
--- a/2d/c_kernels/kokkos/cg.cpp
+++ b/2d/c_kernels/kokkos/cg.cpp
@@ -67,19 +67,19 @@ void cg_calc_w(
         const int x, const int y, const int halo_depth, KView w, 
         KView p, KView kx, KView ky, double* pw) 
 {
-    const int x_inner = x - 2*halo_depth;
-    const int y_inner = y - 2*halo_depth;
-    const int off0 = halo_depth*(x + 1);
 
-    parallel_reduce(x_inner*y_inner, KOKKOS_LAMBDA (const int& i, double& pw_temp)
+    parallel_reduce(x*y, KOKKOS_LAMBDA (const int& index, double& pw_temp)
     {
-      const int col = i % x_inner;
-      const int row = i / x_inner;
-      const int index = off0 + col + row*x;
+      const size_t kk = index % x;
+      const size_t jj = index / x;
 
-      const double smvp = SMVP(p);
-      w(index) = smvp;
-      pw_temp += smvp*p(index);
+      if(kk >= halo_depth && kk < x - halo_depth &&
+         jj >= halo_depth && jj < y - halo_depth)
+      {
+          const double smvp = SMVP(p);
+          w(index) = smvp;
+          pw_temp += w(index)*p(index);
+      }
     }, *pw);
 }
 

--- a/2d/c_kernels/kokkos/cg.cpp
+++ b/2d/c_kernels/kokkos/cg.cpp
@@ -67,18 +67,19 @@ void cg_calc_w(
         const int x, const int y, const int halo_depth, KView w, 
         KView p, KView kx, KView ky, double* pw) 
 {
-    parallel_reduce(x*y, KOKKOS_LAMBDA (const int index, double& pw_temp)
-    {
-        const size_t kk = index % x; 
-        const size_t jj = index / x; 
+    const int x_inner = x - 2*halo_depth;
+    const int y_inner = y - 2*halo_depth;
+    const int off0 = halo_depth*(x + 1);
 
-        if(kk >= halo_depth && kk < x - halo_depth &&
-           jj >= halo_depth && jj < y - halo_depth)
-        {
-            const double smvp = SMVP(p);
-            w(index) = smvp;
-            pw_temp += w(index)*p(index);
-        }
+    parallel_reduce(x_inner*y_inner, KOKKOS_LAMBDA (const int& i, double& pw_temp)
+    {
+      const int col = i % x_inner;
+      const int row = i / x_inner;
+      const int index = off0 + col + row*x;
+
+      const double smvp = SMVP(p);
+      w(index) = smvp;
+      pw_temp += smvp*p(index);
     }, *pw);
 }
 
@@ -87,18 +88,19 @@ void cg_calc_ur(
         const int x, const int y, const int halo_depth, KView u, 
         KView r, KView p, KView w, const double alpha, double* rrn) 
 {
-    parallel_reduce(x*y, KOKKOS_LAMBDA (const int index, double& rrn_temp)
-    {
-        const size_t kk = index % x; 
-        const size_t jj = index / x; 
+    const int x_inner = x - 2*halo_depth;
+    const int y_inner = y - 2*halo_depth;
+    const int off0 = halo_depth*(x + 1);
 
-        if(kk >= halo_depth && kk < x - halo_depth &&
-           jj >= halo_depth && jj < y - halo_depth)
-        {
-            u(index) += alpha*p(index);
-            r(index) -= alpha*w(index);
-            rrn_temp += r(index)*r(index);
-        }
+    parallel_reduce(x_inner*y_inner, KOKKOS_LAMBDA (const int& i, double& rrn_temp)
+    {
+      const int col = i % x_inner;
+      const int row = i / x_inner;
+      const int index = off0 + col + row*x;
+
+      u(index) += alpha*p(index);
+      const double r_idx = r(index) - alpha*w(index);
+      rrn_temp += r_idx*r_idx;
     }, *rrn);
 }
 
@@ -107,16 +109,17 @@ void cg_calc_p(
         const int x, const int y, const int halo_depth, const double beta, 
         KView p, KView r) 
 {
-    parallel_for(x*y, KOKKOS_LAMBDA (const int index)
-    {
-        const size_t kk = index % x; 
-        const size_t jj = index / x; 
+    const int x_inner = x - 2*halo_depth;
+    const int y_inner = y - 2*halo_depth;
+    const int off0 = halo_depth*(x + 1);
 
-        if(kk >= halo_depth && kk < x - halo_depth &&
-           jj >= halo_depth && jj < y - halo_depth)
-        {
-            p(index) = beta*p(index) + r(index);
-        }
+    parallel_for(x_inner*y_inner, KOKKOS_LAMBDA (const int& i)
+    {
+      const int col = i % x_inner;
+      const int row = i / x_inner;
+      const int index = off0 + col + row*x;
+
+      p(index) = beta*p(index) + r(index);
     });
 }
 

--- a/2d/c_kernels/kokkos/kernel_initialise.cpp
+++ b/2d/c_kernels/kokkos/kernel_initialise.cpp
@@ -43,32 +43,33 @@ void kernel_initialise(
 
     Kokkos::initialize();
 
-    *density0 = KView("density0", x*y);
-    *density = KView("density", x*y);
-    *energy0 = KView("energy0", x*y);
-    *energy = KView("energy", x*y);
-    *u = KView("u", x*y);
-    *u0 = KView("u0", x*y);
-    *p = KView("p", x*y);
-    *r = KView("r", x*y);
-    *mi = KView("mi", x*y);
-    *w = KView("w", x*y);
-    *kx = KView("kx", x*y);
-    *ky = KView("ky", x*y);
-    *sd = KView("sd", x*y);
-    *volume = KView("volume", x*y);
-    *x_area = KView("x_area", (x+1)*y);
-    *y_area = KView("y_area", x*(y+1));
-    *cell_x = KView("cell_x", x);
-    *cell_y = KView("cell_y", y);
-    *cell_dx = KView("cell_dx", x);
-    *cell_dy = KView("cell_dy", y);
-    *vertex_dx = KView("vertex_dx", (x+1));
-    *vertex_dy = KView("vertex_dy", (y+1));
-    *vertex_x = KView("vertex_x", (x+1));
-    *vertex_y = KView("vertex_y", (y+1));
+    new(density0) KView("density0", x*y);
+    new(density) KView("density", x*y);
+    new(energy0) KView("energy0", x*y);
+    new(energy) KView("energy", x*y);
+    new(u) KView("u", x*y);
+    new(u0) KView("u0", x*y);
+    new(p) KView("p", x*y);
+    new(r) KView("r", x*y);
+    new(mi) KView("mi", x*y);
+    new(w) KView("w", x*y);
+    new(kx) KView("kx", x*y);
+    new(ky) KView("ky", x*y);
+    new(sd) KView("sd", x*y);
+    new(volume) KView("volume", x*y);
+    new(x_area) KView("x_area", (x+1)*y);
+    new(y_area) KView("y_area", x*(y+1));
+    new(cell_x) KView("cell_x", x);
+    new(cell_y) KView("cell_y", y);
+    new(cell_dx) KView("cell_dx", x);
+    new(cell_dy) KView("cell_dy", y);
+    new(vertex_dx) KView("vertex_dx", (x+1));
+    new(vertex_dy) KView("vertex_dy", (y+1));
+    new(vertex_x) KView("vertex_x", (x+1));
+    new(vertex_y) KView("vertex_y", (y+1));
 
-    *comms_buffer = KView("comms_buffer", MAX(x, y)*settings->halo_depth);
+    new(comms_buffer) KView("comms_buffer", MAX(x, y)*settings->halo_depth);
+    new(host_comms_mirror) KView::HostMirror(); 
     *host_comms_mirror = Kokkos::create_mirror_view(*comms_buffer);
 
     allocate_buffer(cg_alphas, settings->max_iters, 1);

--- a/2d/c_kernels/kokkos_np/kernel_initialise.cpp
+++ b/2d/c_kernels/kokkos_np/kernel_initialise.cpp
@@ -43,32 +43,33 @@ void kernel_initialise(
 
     Kokkos::initialize();
 
-    *density0 = KView("density0", x*y);
-    *density = KView("density", x*y);
-    *energy0 = KView("energy0", x*y);
-    *energy = KView("energy", x*y);
-    *u = KView("u", x*y);
-    *u0 = KView("u0", x*y);
-    *p = KView("p", x*y);
-    *r = KView("r", x*y);
-    *mi = KView("mi", x*y);
-    *w = KView("w", x*y);
-    *kx = KView("kx", x*y);
-    *ky = KView("ky", x*y);
-    *sd = KView("sd", x*y);
-    *volume = KView("volume", x*y);
-    *x_area = KView("x_area", (x+1)*y);
-    *y_area = KView("y_area", x*(y+1));
-    *cell_x = KView("cell_x", x);
-    *cell_y = KView("cell_y", y);
-    *cell_dx = KView("cell_dx", x);
-    *cell_dy = KView("cell_dy", y);
-    *vertex_dx = KView("vertex_dx", (x+1));
-    *vertex_dy = KView("vertex_dy", (y+1));
-    *vertex_x = KView("vertex_x", (x+1));
-    *vertex_y = KView("vertex_y", (y+1));
+    new(density0) KView("density0", x*y);
+    new(density) KView("density", x*y);
+    new(energy0) KView("energy0", x*y);
+    new(energy) KView("energy", x*y);
+    new(u) KView("u", x*y);
+    new(u0) KView("u0", x*y);
+    new(p) KView("p", x*y);
+    new(r) KView("r", x*y);
+    new(mi) KView("mi", x*y);
+    new(w) KView("w", x*y);
+    new(kx) KView("kx", x*y);
+    new(ky) KView("ky", x*y);
+    new(sd) KView("sd", x*y);
+    new(volume) KView("volume", x*y);
+    new(x_area) KView("x_area", (x+1)*y);
+    new(y_area) KView("y_area", x*(y+1));
+    new(cell_x) KView("cell_x", x);
+    new(cell_y) KView("cell_y", y);
+    new(cell_dx) KView("cell_dx", x);
+    new(cell_dy) KView("cell_dy", y);
+    new(vertex_dx) KView("vertex_dx", (x+1));
+    new(vertex_dy) KView("vertex_dy", (y+1));
+    new(vertex_x) KView("vertex_x", (x+1));
+    new(vertex_y) KView("vertex_y", (y+1));
 
-    *comms_buffer = KView("comms_buffer", MAX(x, y)*settings->halo_depth);
+    new(comms_buffer) KView("comms_buffer", MAX(x, y)*settings->halo_depth);
+    new(host_comms_mirror) KView::HostMirror(); 
     *host_comms_mirror = Kokkos::create_mirror_view(*comms_buffer);
 
     allocate_buffer(cg_alphas, settings->max_iters, 1);

--- a/2d/c_kernels/kokkos_orig/kernel_initialise.cpp
+++ b/2d/c_kernels/kokkos_orig/kernel_initialise.cpp
@@ -43,32 +43,33 @@ void kernel_initialise(
 
     Kokkos::initialize();
 
-    *density0 = KView("density0", x*y);
-    *density = KView("density", x*y);
-    *energy0 = KView("energy0", x*y);
-    *energy = KView("energy", x*y);
-    *u = KView("u", x*y);
-    *u0 = KView("u0", x*y);
-    *p = KView("p", x*y);
-    *r = KView("r", x*y);
-    *mi = KView("mi", x*y);
-    *w = KView("w", x*y);
-    *kx = KView("kx", x*y);
-    *ky = KView("ky", x*y);
-    *sd = KView("sd", x*y);
-    *volume = KView("volume", x*y);
-    *x_area = KView("x_area", (x+1)*y);
-    *y_area = KView("y_area", x*(y+1));
-    *cell_x = KView("cell_x", x);
-    *cell_y = KView("cell_y", y);
-    *cell_dx = KView("cell_dx", x);
-    *cell_dy = KView("cell_dy", y);
-    *vertex_dx = KView("vertex_dx", (x+1));
-    *vertex_dy = KView("vertex_dy", (y+1));
-    *vertex_x = KView("vertex_x", (x+1));
-    *vertex_y = KView("vertex_y", (y+1));
+    new(density0) KView("density0", x*y);
+    new(density) KView("density", x*y);
+    new(energy0) KView("energy0", x*y);
+    new(energy) KView("energy", x*y);
+    new(u) KView("u", x*y);
+    new(u0) KView("u0", x*y);
+    new(p) KView("p", x*y);
+    new(r) KView("r", x*y);
+    new(mi) KView("mi", x*y);
+    new(w) KView("w", x*y);
+    new(kx) KView("kx", x*y);
+    new(ky) KView("ky", x*y);
+    new(sd) KView("sd", x*y);
+    new(volume) KView("volume", x*y);
+    new(x_area) KView("x_area", (x+1)*y);
+    new(y_area) KView("y_area", x*(y+1));
+    new(cell_x) KView("cell_x", x);
+    new(cell_y) KView("cell_y", y);
+    new(cell_dx) KView("cell_dx", x);
+    new(cell_dy) KView("cell_dy", y);
+    new(vertex_dx) KView("vertex_dx", (x+1));
+    new(vertex_dy) KView("vertex_dy", (y+1));
+    new(vertex_x) KView("vertex_x", (x+1));
+    new(vertex_y) KView("vertex_y", (y+1));
 
-    *comms_buffer = KView("comms_buffer", MAX(x, y)*settings->halo_depth);
+    new(comms_buffer) KView("comms_buffer", MAX(x, y)*settings->halo_depth);
+    new(host_comms_mirror) KView::HostMirror(); 
     *host_comms_mirror = Kokkos::create_mirror_view(*comms_buffer);
 
     allocate_buffer(cg_alphas, settings->max_iters, 1);


### PR DESCRIPTION
The View handles are allocated as part of a struct using malloc in a
C function. This leaves the views uninitialized. Later new Views are
assigned to those uninitialized ones. This is illegal behaviour.
The Views constructor must be called before an assignment operator can
be used. For a while this would just lead to undefined behavior in
certain corner cases, with the latest Kokkos this will lead typically
to segmentation faults. The usage scenario can still be supported by
using a placement new operator for the first assignment operations.
