### PR TITLE
*fix* corrected offsets when executing teampolicy things

### DIFF
--- a/2d/c_kernels/kokkos_np/cg.hpp
+++ b/2d/c_kernels/kokkos_np/cg.hpp
@@ -133,10 +133,10 @@ struct CGCalcW
     void operator()(const team_member& team, value_type& pw) const
     {
         double pw_team = 0.0;
-        const int team_offset = (team.league_rank() + halo_depth)*y;
+        const int team_offset = (team.league_rank() + halo_depth)*x;
 
         Kokkos::parallel_reduce(
-                Kokkos::TeamThreadRange(team, halo_depth, y-halo_depth),
+                Kokkos::TeamThreadRange(team, halo_depth, x-halo_depth),
                 [&] (const int &j, double& pw_thread)
         {
             const int index = team_offset + j;
@@ -178,10 +178,10 @@ struct CGCalcUR
     void operator()(const team_member& team, value_type& rrn) const
     {
         double rrn_team = 0.0;
-        const int team_offset = (team.league_rank() + halo_depth)*y;
+        const int team_offset = (team.league_rank() + halo_depth)*x;
 
         Kokkos::parallel_reduce(
-                Kokkos::TeamThreadRange(team, halo_depth, y-halo_depth),
+                Kokkos::TeamThreadRange(team, halo_depth, x-halo_depth),
                 [&] (const int &j, double& rrn_thread)
         {
             const int index = team_offset + j;
@@ -221,10 +221,10 @@ struct CGCalcP
     KOKKOS_INLINE_FUNCTION
     void operator()(const team_member& team) const
     {
-        const int team_offset = (team.league_rank() + halo_depth)*y;
+        const int team_offset = (team.league_rank() + halo_depth)*x;
 
         Kokkos::parallel_for(
-            Kokkos::TeamThreadRange(team, halo_depth, y-halo_depth),
+            Kokkos::TeamThreadRange(team, halo_depth, x-halo_depth),
             [&] (const int &j)
         {
             const int index = team_offset + j;

--- a/2d/c_kernels/kokkos_np/cheby.hpp
+++ b/2d/c_kernels/kokkos_np/cheby.hpp
@@ -58,10 +58,10 @@ struct ChebyCalcU
     KOKKOS_INLINE_FUNCTION
     void operator()(const team_member& team) const
     {
-        const int team_offset = (team.league_rank() + halo_depth)*y;
+        const int team_offset = (team.league_rank() + halo_depth)*x;
 
         Kokkos::parallel_for(
-            Kokkos::TeamThreadRange(team, halo_depth, y-halo_depth),
+            Kokkos::TeamThreadRange(team, halo_depth, x-halo_depth),
             [&] (const int &j)
         {
             const int index = team_offset + j;
@@ -94,10 +94,10 @@ struct ChebyIterate
     KOKKOS_INLINE_FUNCTION
         void operator()(const team_member& team) const
         {
-            const int team_offset = (team.league_rank() + halo_depth)*y;
+            const int team_offset = (team.league_rank() + halo_depth)*x;
 
             Kokkos::parallel_for(
-                Kokkos::TeamThreadRange(team, halo_depth, y-halo_depth),
+                Kokkos::TeamThreadRange(team, halo_depth, x-halo_depth),
                 [&] (const int &j)
             {
                 const int index = team_offset + j;

--- a/2d/c_kernels/kokkos_np/kernel_interface.cpp
+++ b/2d/c_kernels/kokkos_np/kernel_interface.cpp
@@ -230,7 +230,7 @@ void run_cg_calc_w(Chunk* chunk, Settings* settings, double* pw)
       chunk->p, chunk->kx, chunk->ky);
 
   parallel_reduce(
-      TeamPolicy<DEVICE>(chunk->x - 2*settings->halo_depth, AUTO), 
+      TeamPolicy<DEVICE>(chunk->y - 2*settings->halo_depth, AUTO), 
       cg_calc_w, *pw);
 
   STOP_PROFILING(settings->kernel_profile, __func__);
@@ -246,7 +246,7 @@ void run_cg_calc_ur(
       chunk->p, chunk->w, alpha);
 
   parallel_reduce(
-      TeamPolicy<DEVICE>(chunk->x - 2*settings->halo_depth, AUTO), 
+      TeamPolicy<DEVICE>(chunk->y - 2*settings->halo_depth, AUTO), 
       cg_calc_ur, *rrn);
 
   STOP_PROFILING(settings->kernel_profile, __func__);
@@ -260,7 +260,7 @@ void run_cg_calc_p(Chunk* chunk, Settings* settings, double beta)
       chunk->x, chunk->y, settings->halo_depth, beta, chunk->p, chunk->r);
 
   parallel_for(
-      TeamPolicy<DEVICE>(chunk->x - 2*settings->halo_depth, AUTO), 
+      TeamPolicy<DEVICE>(chunk->y - 2*settings->halo_depth, AUTO), 
       cg_calc_p);
 
   STOP_PROFILING(settings->kernel_profile, __func__);
@@ -292,14 +292,14 @@ void run_cheby_iterate(
       chunk->kx, chunk->ky);
 
   parallel_for(
-      TeamPolicy<DEVICE>(chunk->x - 2*settings->halo_depth, AUTO), 
+      TeamPolicy<DEVICE>(chunk->y - 2*settings->halo_depth, AUTO), 
       cheby_iterate);
 
   ChebyCalcU<DEVICE> cheby_calc_u(
       chunk->x, chunk->y, settings->halo_depth, chunk->p, chunk->u);
 
   parallel_for(
-      TeamPolicy<DEVICE>(chunk->x - 2*settings->halo_depth, AUTO), 
+      TeamPolicy<DEVICE>(chunk->y - 2*settings->halo_depth, AUTO), 
       cheby_calc_u);
 
   STOP_PROFILING(settings->kernel_profile, __func__);
@@ -363,7 +363,7 @@ void run_ppcg_inner_iteration(
       chunk->u, chunk->kx, chunk->ky);
 
   parallel_for(
-      TeamPolicy<DEVICE>(chunk->x - 2*settings->halo_depth, AUTO), 
+      TeamPolicy<DEVICE>(chunk->y - 2*settings->halo_depth, AUTO), 
       ppcg_calc_ur);
 
   PPCGCalcSd<DEVICE> ppcg_calc_sd(
@@ -371,7 +371,7 @@ void run_ppcg_inner_iteration(
       chunk->sd, chunk->r);
 
   parallel_for(
-      TeamPolicy<DEVICE>(chunk->x - 2*settings->halo_depth, AUTO), 
+      TeamPolicy<DEVICE>(chunk->y - 2*settings->halo_depth, AUTO), 
       ppcg_calc_sd);
 
   STOP_PROFILING(settings->kernel_profile, __func__);

--- a/2d/c_kernels/kokkos_np/ppcg.hpp
+++ b/2d/c_kernels/kokkos_np/ppcg.hpp
@@ -54,10 +54,10 @@ struct PPCGCalcUR
     KOKKOS_INLINE_FUNCTION
         void operator()(const team_member& team) const
         {
-            const int team_offset = (team.league_rank() + halo_depth)*y;
+            const int team_offset = (team.league_rank() + halo_depth)*x;
 
             Kokkos::parallel_for(
-                Kokkos::TeamThreadRange(team, halo_depth, y-halo_depth),
+                Kokkos::TeamThreadRange(team, halo_depth, x-halo_depth),
                 [&] (const int &j)
             {
                 const int index = team_offset + j;
@@ -93,10 +93,10 @@ struct PPCGCalcSd
     KOKKOS_INLINE_FUNCTION
     void operator()(const team_member& team) const
     {
-        const int team_offset = (team.league_rank() + halo_depth)*y;
+        const int team_offset = (team.league_rank() + halo_depth)*x;
 
         Kokkos::parallel_for(
-            Kokkos::TeamThreadRange(team, halo_depth, y-halo_depth),
+            Kokkos::TeamThreadRange(team, halo_depth, x-halo_depth),
             [&] (const int &j)
         {
             const int index = team_offset + j;


### PR DESCRIPTION
previous code was working just fine when x==y, so it failed with MPI when number of processes was not a square number