### PR TITLE
modify definition of send_recv_message to fit the MPI ISend spec

### DIFF
--- a/driver/comms.cpp
+++ b/driver/comms.cpp
@@ -14,7 +14,7 @@ void initialise_ranks(Settings &settings) {
 void finalise_comms() { MPI_Finalize(); }
 
 // Sends a message out and receives a message in
-void send_recv_message(Settings &settings, double *send_buffer, double *recv_buffer, int buffer_len, int neighbour, int send_tag,
+void send_recv_message(Settings &settings, const double *send_buffer, double *recv_buffer, int buffer_len, int neighbour, int send_tag,
                        int recv_tag, MPI_Request *send_request, MPI_Request *recv_request) {
   START_PROFILING(settings.kernel_profile);
 

--- a/driver/comms.h
+++ b/driver/comms.h
@@ -22,5 +22,5 @@ void initialise_ranks(Settings &settings);
 void sum_over_ranks(Settings &settings, double *a);
 void min_over_ranks(Settings &settings, double *a);
 void wait_for_requests(Settings &settings, int num_requests, MPI_Request *requests);
-void send_recv_message(Settings &settings, double *send_buffer, double *recv_buffer, int buffer_len, int neighbour, int send_tag,
+void send_recv_message(Settings &settings, const double *send_buffer, double *recv_buffer, int buffer_len, int neighbour, int send_tag,
                        int recv_tag, MPI_Request *send_request, MPI_Request *recv_request);


### PR DESCRIPTION
This commit changes the definition of send_recv_message to match the MPI spec. Since this commit affects all variants of Tealeaf, I have confirmed that it has no issues fitting in with the current omp, sycl-acc and sycl-usm implementations.