### PR TITLE
fix clause to properly override ${DEFAULT_${BUILD_TYPE}_CXX_FLAGS}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ message(STATUS "Default ${CMAKE_BUILD_TYPE} flags are `${DEFAULT_${BUILD_TYPE}_C
 # setup common build flag defaults if there are no overrides
 if (NOT DEFINED ${BUILD_TYPE}_CXX_FLAGS)
     set(ACTUAL_${BUILD_TYPE}_CXX_FLAGS ${DEFAULT_${BUILD_TYPE}_CXX_FLAGS})
-elseif ()
+else ()
     set(ACTUAL_${BUILD_TYPE}_CXX_FLAGS ${${BUILD_TYPE}_CXX_FLAGS})
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,8 @@ if (NOT DEFINED ${BUILD_TYPE}_CXX_FLAGS)
     set(ACTUAL_${BUILD_TYPE}_CXX_FLAGS ${DEFAULT_${BUILD_TYPE}_CXX_FLAGS})
 else ()
     set(ACTUAL_${BUILD_TYPE}_CXX_FLAGS ${${BUILD_TYPE}_CXX_FLAGS})
+    separate_arguments(${BUILD_TYPE}_CXX_FLAGS)
+    separate_arguments(ACTUAL_${BUILD_TYPE}_CXX_FLAGS)
 endif ()
 
 if (NOT ENABLE_MPI)


### PR DESCRIPTION
`elseif ()` needs a condition, which is absent in this case, causing the override of `${DEFAULT_${BUILD_TYPE}_CXX_FLAGS}` to fail.